### PR TITLE
Defaulting recovery of getIsTrustTaxable to true until trust matching…

### DIFF
--- a/app/connectors/SubmissionDraftConnector.scala
+++ b/app/connectors/SubmissionDraftConnector.scala
@@ -38,7 +38,10 @@ class SubmissionDraftConnector @Inject()(http: HttpClient, config : FrontendAppC
     http.GET[SubmissionDraftResponse](s"$submissionsBaseUrl/$draftId/$section")
   }
 
+  // TODO - once the trust matching journey has been fixed to set a value for trustTaxable the recover can be removed
   def getIsTrustTaxable(draftId: String)(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[Boolean] = {
-    http.GET[Boolean](s"$submissionsBaseUrl/$draftId/is-trust-taxable")
+    http.GET[Boolean](s"$submissionsBaseUrl/$draftId/is-trust-taxable").recover {
+      case _ => true
+    }
   }
 }

--- a/test/connectors/SubmissionDraftConnectorSpec.scala
+++ b/test/connectors/SubmissionDraftConnectorSpec.scala
@@ -147,6 +147,19 @@ class SubmissionDraftConnectorSpec extends SpecBase with MustMatchers with Optio
         val result: Boolean = Await.result(connector.getIsTrustTaxable(testDraftId), Duration.Inf)
         result.booleanValue() mustBe false
       }
+
+      "recover to true as default" in {
+        server.stubFor(
+          get(urlEqualTo(s"$submissionsUrl/$testDraftId/is-trust-taxable"))
+            .willReturn(
+              aResponse()
+                .withStatus(Status.NOT_FOUND)
+            )
+        )
+
+        val result: Boolean = Await.result(connector.getIsTrustTaxable(testDraftId), Duration.Inf)
+        result.booleanValue() mustBe true
+      }
     }
   }
 }


### PR DESCRIPTION
… journey is fixed for non-taxable.