### PR TITLE
[TRUS-3641] - Fix issue with open details section on info page in IE11

### DIFF
--- a/app/assets/javascripts/registertrustbeneficiaryfrontend.js
+++ b/app/assets/javascripts/registertrustbeneficiaryfrontend.js
@@ -18,6 +18,7 @@ $(document).ready(function() {
   // =====================================================
 
   GOVUK.shimLinksWithButtonRole.init();
+  GOVUK.details.init();
 
   // =====================================================
   // Back link mimics browser back functionality

--- a/app/assets/stylesheets/registertrustbeneficiaryfrontend-app.scss
+++ b/app/assets/stylesheets/registertrustbeneficiaryfrontend-app.scss
@@ -264,3 +264,7 @@ $error-colour: #d4351c;
     padding-left: 20px;
     border-left: 5px solid #b1b4b6;
 }
+
+.no-details details summary .arrow-closed {
+    display: none;
+}


### PR DESCRIPTION
1, initialised the details polyfil
2. Overriding the declaration from _details.scss for the display for the arrow when the no-details class has been added to from "inline-block" to "none". As per https://github.com/hmrc/assets-frontend/issues/1016 which also effects IE11 by applying 1). above
