### PR TITLE
TRUS-4273 [CS] add HeadingWithCaption hidden text

### DIFF
--- a/app/views/components/HeadingWithCaption.scala.html
+++ b/app/views/components/HeadingWithCaption.scala.html
@@ -18,9 +18,9 @@
  subHeading: SubHeading
 )
 
-@(messagePrefix: String, optionalParam: Option[String] = None, captionParam: Option[String] = None)(implicit messages: Messages)
+@(messagePrefix: String, optionalParam: Option[String] = None, captionParam: Option[String] = None, hiddenText: Boolean = true)(implicit messages: Messages)
 
 <h1 class="govuk-heading-l">
- @subHeading(s"$messagePrefix.caption", captionParam.getOrElse(""))
+ @subHeading(s"$messagePrefix.caption", captionParam.getOrElse(""), hiddenText)
  @messages(s"$messagePrefix.heading", optionalParam.getOrElse(""))
 </h1>

--- a/app/views/components/SubHeading.scala.html
+++ b/app/views/components/SubHeading.scala.html
@@ -16,6 +16,11 @@
 
 @this()
 
-@(key: String, param: String)(implicit messages: Messages)
+@(key: String, param: String, hiddenText: Boolean = true)(implicit messages: Messages)
 
-<span class="govuk-caption-l">@messages(key, param)</span>
+<span class="govuk-caption-l">
+ @if(hiddenText){
+  <span class="govuk-visually-hidden">@messages(s"$key.hidden")</span>
+ }
+ @messages(key, param)
+</span>

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -54,15 +54,20 @@ trait ViewSpecBase extends SpecBase {
     headers.first.text.replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args: _*).replaceAll("&nbsp;", " ")
   }
 
-  def assertPageTitleWithCaptionEqualsMessages(doc: Document, expectedCaptionMessageKey: String, captionParam: String, expectedMessageKey: String) = {
+  def assertPageTitleWithCaptionEqualsMessages(doc: Document, expectedMessageKey: String): Assertion = {
     val headers = doc.getElementsByTag("h1")
     headers.size mustBe 1
     val actual = headers.first.text.replaceAll("\u00a0", " ")
 
-    val expectedCaption = messages(expectedCaptionMessageKey, captionParam).replaceAll("&nbsp;", " ")
-    val expectedHeading = messages(expectedMessageKey).replaceAll("&nbsp;", " ")
+    val expectedCaptionMessageKey = s"$expectedMessageKey.caption"
+    val expectedHiddenMessageKey = s"$expectedMessageKey.caption.hidden"
+    val expectedHeadingMessageKey = s"$expectedMessageKey.heading"
 
-    actual mustBe s"$expectedCaption $expectedHeading"
+    val expectedHidden = messages(expectedHiddenMessageKey).replaceAll("&nbsp;", " ")
+    val expectedCaption = messages(expectedCaptionMessageKey).replaceAll("&nbsp;", " ")
+    val expectedHeading = messages(expectedHeadingMessageKey).replaceAll("&nbsp;", " ")
+
+    actual mustBe s"$expectedHidden $expectedCaption $expectedHeading"
 
   }
 
@@ -84,7 +89,7 @@ trait ViewSpecBase extends SpecBase {
     assert(doc.getElementById(id) == null, "\n\nElement " + id + " was rendered on the page.\n")
   }
 
-  def assertRenderedByClass(doc: Document, cssClass: String) =
+  def assertRenderedByClass(doc: Document, cssClass: String): Assertion =
     assert(doc.getElementsByClass(cssClass) != null, "\n\nElement " + cssClass + " was not rendered on the page.\n")
 
   def assertNotRenderedByClass(doc: Document, className: String): Assertion = {

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -68,7 +68,6 @@ trait ViewBehaviours extends ViewSpecBase {
 
   def normalPageTitleWithCaption(view: HtmlFormat.Appendable,
                                  messageKeyPrefix: String,
-                                 captionParam: String,
                                  expectedGuidanceKeys: String*): Unit = {
 
     "behave like a normal page" when {
@@ -91,7 +90,7 @@ trait ViewBehaviours extends ViewSpecBase {
         "display the correct page title with caption" in {
 
           val doc = asDocument(view)
-          assertPageTitleWithCaptionEqualsMessages(doc, s"$messageKeyPrefix.caption",  captionParam, s"$messageKeyPrefix.heading")
+          assertPageTitleWithCaptionEqualsMessages(doc, messageKeyPrefix)
         }
 
         "display the correct guidance" in {

--- a/test/views/register/beneficiaries/Info4mldViewSpec.scala
+++ b/test/views/register/beneficiaries/Info4mldViewSpec.scala
@@ -29,7 +29,6 @@ class Info4mldViewSpec extends ViewBehaviours {
     val applyView = view.apply(fakeDraftId)(fakeRequest, messages)
 
     behave like normalPageTitleWithCaption(applyView, "beneficiaryInfo",
-      "caption",
       "subheading1",
       "paragraph1",
       "bulletpoint1",

--- a/test/views/register/beneficiaries/Info5mldViewSpec.scala
+++ b/test/views/register/beneficiaries/Info5mldViewSpec.scala
@@ -30,7 +30,6 @@ class Info5mldViewSpec extends ViewBehaviours {
       val applyView = view.apply(fakeDraftId, isTaxable = false)(fakeRequest, messages)
 
       behave like normalPageTitleWithCaption(applyView, "beneficiaryInfo.5mld",
-        "caption",
         "subheading1",
         "paragraph11",
         "bulletpoint11",


### PR DESCRIPTION
Matches behaviour in Registration trustees to read "This section is"
<img width="1079" alt="Screenshot 2021-07-13 at 13 43 29" src="https://user-images.githubusercontent.com/62263396/125453830-d436b44e-6ec7-4725-b7ac-52e81260fb81.png">
