### PR TITLE
DDCE-5067: Update to stop form submission with smart apostrophes

### DIFF
--- a/app/config/annotations/CharityBeneficiary.java
+++ b/app/config/annotations/CharityBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/ClassOfBeneficiaries.java
+++ b/app/config/annotations/ClassOfBeneficiaries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/CompanyBeneficiary.java
+++ b/app/config/annotations/CompanyBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/EmploymentRelatedBeneficiary.java
+++ b/app/config/annotations/EmploymentRelatedBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/IndividualBeneficiary.java
+++ b/app/config/annotations/IndividualBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/OtherBeneficiary.java
+++ b/app/config/annotations/OtherBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/annotations/TrustBeneficiary.java
+++ b/app/config/annotations/TrustBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/InternationalAddressFormProvider.scala
+++ b/app/forms/InternationalAddressFormProvider.scala
@@ -45,8 +45,7 @@ class InternationalAddressFormProvider @Inject() extends Mappings {
               regexp(Validation.addressLineRegex, "internationalAddress.error.line2.invalidCharacters")
             )),
       "line3" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "internationalAddress.error.line3.length"),

--- a/app/forms/UKAddressFormProvider.scala
+++ b/app/forms/UKAddressFormProvider.scala
@@ -45,8 +45,7 @@ class UKAddressFormProvider @Inject() extends Mappings {
               regexp(Validation.addressLineRegex, "ukAddress.error.line2.invalidCharacters")
             )),
       "line3" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "ukAddress.error.line3.length"),
@@ -54,8 +53,7 @@ class UKAddressFormProvider @Inject() extends Mappings {
             ))
         ).transform(emptyToNone, identity[Option[String]]),
       "line4" ->
-        optional(Forms.text
-          .transform(trimWhitespace, identity[String])
+        optional(text()
           .verifying(
             firstError(
               maxLength(35, "ukAddress.error.line4.length"),

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -43,8 +43,7 @@ trait Formatters {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
       data.get(key) match {
         case None | Some("") => Left(Seq(FormError(key, errorKey)))
-        case Some(s) =>
-          Right(s.trim)
+        case Some(s)         => Right(s.trim.replace("‘", "'").replace("’", "'"))
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.19.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.20.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.4.0")
 addSbtPlugin("com.typesafe.play"    % "sbt-plugin"            % "2.8.21")
 addSbtPlugin("org.scalastyle"       % "scalastyle-sbt-plugin" % "1.0.0")

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -53,6 +53,11 @@ class MappingsSpec extends AnyWordSpec with Matchers with OptionValues with Mapp
       result.get mustEqual "foobar"
     }
 
+    "filter out smart apostrophes on binding" in {
+      val boundValue = testForm bind Map("value" -> "We’re ‘aving fish ‘n’ chips for tea")
+      boundValue.get mustEqual "We're 'aving fish 'n' chips for tea"
+    }
+
     "not bind an empty string" in {
       val result = testForm.bind(Map("value" -> ""))
       result.errors must contain(FormError("value", "error.required"))


### PR DESCRIPTION
Load of screen shots showing adding both smart apostrophes to each text field:

![Screenshot 2024-02-02 at 14 05 51](https://github.com/hmrc/register-trust-beneficiary-frontend/assets/125281117/5b09874b-37d1-45c2-8663-56f1cb335fd6)

![Screenshot 2024-02-02 at 14 06 10](https://github.com/hmrc/register-trust-beneficiary-frontend/assets/125281117/69e85ee6-0d10-4632-872f-b623a4581611)

![Screenshot 2024-02-02 at 14 07 21](https://github.com/hmrc/register-trust-beneficiary-frontend/assets/125281117/d45fdef0-3d42-41cf-9b48-5235aec5f91e)

![Screenshot 2024-02-02 at 14 08 28](https://github.com/hmrc/register-trust-beneficiary-frontend/assets/125281117/c9ecc0f0-4fc1-4240-afbf-f6fca87c98e7)

![Screenshot 2024-02-02 at 14 25 36](https://github.com/hmrc/register-trust-beneficiary-frontend/assets/125281117/5946cc5d-6022-4590-a68d-fae46f2d4de7)
